### PR TITLE
Fix for invalid packageName generation on Windows

### DIFF
--- a/src/main/groovy/me/seeber/gradle/wsimport/WsimportTask.groovy
+++ b/src/main/groovy/me/seeber/gradle/wsimport/WsimportTask.groovy
@@ -64,7 +64,7 @@ public class WsimportTask extends DefaultTask {
                 JavaExecAction action = getActionFactory().newJavaExecAction()
 
                 File relativeSourceFile = new File(inputDir.toURI().relativize(change.file.toURI()).toString())
-                String packageName = relativeSourceFile.parent.replace("/", ".")
+                String packageName = relativeSourceFile.parent.replace(File.separator, ".")
 
                 Map<String, Object> options = (Map<String, Object>)[
                     "quiet": true,


### PR DESCRIPTION
Replaced hardcoded  separator "/" with platform dependant File.separator.
