### PR TITLE
Fix Issue #6: Empty B-classpath on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Applying the plugin
 
 ```gradle
 plugins {
-    id "me.seeber.gradle-wsimport-plugin" version "1.1.0"
+    id "me.seeber.wsimport" version "1.1.1"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can use the [download plugin](https://github.com/michel-kraemer/gradle-downl
 
 ```gradle
 plugins {
-    id "de.undercouch.download" version "1.2"
+    id "de.undercouch.download" version "3.3.0"
 }
 
 import de.undercouch.gradle.tasks.download.Download

--- a/src/doc/templates/README.template.md
+++ b/src/doc/templates/README.template.md
@@ -10,7 +10,7 @@ Applying the plugin
 
 ```gradle
 plugins {
-    id "me.seeber.gradle-wsimport-plugin" version "${project.version}"
+    id "me.seeber.wsimport" version "${project.version}"
 }
 ```
 

--- a/src/main/java/me/seeber/gradle/wsimport/WsimportTask.java
+++ b/src/main/java/me/seeber/gradle/wsimport/WsimportTask.java
@@ -152,7 +152,10 @@ public class WsimportTask extends ConventionTask {
         options.put("s", getDestinationDir());
         options.put("extension", true);
         options.put("Xnocompile", true);
-        options.put("B-classpath", getProject().getConfigurations().getAt("xjc").getAsPath());
+        final Configuration xjcConfig = getProject().getConfigurations().getAt("xjc");
+        if (xjcConfig != null && !xjcConfig.isEmpty()) {
+            options.put("B-classpath", xjcConfig.getAsPath());
+        }
 
         for (String extension : getXjcExtensions()) {
             options.put("B-X" + extension, true);


### PR DESCRIPTION
Hi,

this pull request should fix the Issue #6 in that a B-classpath option is only added, when it is actually configured.

I also included the updates to the readme file from sebkoller, since they are not yet merged.
Please merge and publish this, so we can use your very handy gradle plugin on our windows machines!

Thanks a lot!